### PR TITLE
1.0.1 Release

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -14,9 +14,15 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-        java: [8, 17]
-        jdk: ['temurin']
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        java:
+          - 8
+          - 17
+        jdk:
+          - temurin
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -29,6 +35,6 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Run tests
-        run: sbt test publishM2
-      - name: Maven integration tests
-        run: sbt mavenTests
+        run: sbt --batch test publishM2 mavenTests
+        # run: sbt --batch "testOnly nl.jarmoniuk.download.DownloadMojoTest"
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ hs_err_pid*
 **/.bsp/*
 **/.metals/*
 **/.vscode/*
+*.code-workspace
+.idea
+.metals
+.vscode
+.bsp
 **/target/
 **/lib/*.jar
 it/~/.m2/**

--- a/README.adoc
+++ b/README.adoc
@@ -10,9 +10,9 @@ image:https://github.com/ajarmoniuk/jetty-download-maven-plugin/actions/workflow
 
 == _What_ and _why_
 
-In contradiction to other avaialable Maven plugins for downloading resources, this one uses https://www.eclipse.org/jetty/[Eclipse Jetty] version @jettyVersion@, and tries to do only one thing.
+In contradiction to other available Maven plugins for downloading resources, this one uses https://www.eclipse.org/jetty/[Eclipse Jetty] version @jettyVersion@, and tries to do only one thing.
 
-A big part of the _why_ is -- because it's _fun!_ That's also why this plugin, whilst working with Java 8 and Maven, is written using Scala 3 (Dotty). Despite the ludic component to it, the main goal is to offer solid functionality with the Unix philosophy of doing just one thing -- but doing it well.
+The plugin is written using Scala 3 (Dotty).
 
 == Similar plugins
 
@@ -37,7 +37,7 @@ The plugin only offers one goal, `download`, which should download the given res
   <plugin>
     <groupId>nl.jarmoniuk</groupId>
     <artifactId>jetty-download-maven-plugin</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.0.1</version>
     <executions>
       <execution>
         <id>download-file</id>

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 val jettyVersion = "9.4.51.v20230217"
 val mavenVersion = "3.3.9"
 
-version := "1.1.0-SNAPSHOT"
+version := "1.0.1"
 
 ThisBuild / name := "Jetty Download Maven Plugin"
 ThisBuild / organization := "nl.jarmoniuk"
 ThisBuild / organizationName := "Andrzej Jarmoniuk"
 ThisBuild / versionScheme := Option apply "semver-spec"
 ThisBuild / description := "Simple plugin for downloading resources based on Eclipse Jetty"
-ThisBuild / scalaVersion := "3.2.2"
+scalaVersion := "3.2.2"
 ThisBuild / homepage := Option apply url("https://www.jarmoniuk.nl/jetty-download/")
 ThisBuild / licenses += "Apache 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
 ThisBuild / developers := List(
@@ -29,7 +29,8 @@ ThisBuild / publishTo := {
   if (isSnapshot.value) Some("snapshots" at nexus + "/content/repositories/snapshots")
   else Some("releases" at nexus + "/service/local/staging/deploy/maven2")
 }
-
+ThisBuild / javacOptions ++= Seq("-source", "1.8", "-target", "1.8") 
+ThisBuild / test / parallelExecution := false
 ThisBuild / crossPaths := false
 ThisBuild / pomPostProcess := {
   import scala.xml.{Node, NodeSeq, *}
@@ -86,8 +87,6 @@ lazy val root = project in file(".") settings (
     "org.scalatest" %% "scalatest" % "3.2.15" % Test,
   )
 )
-
-javaOptions in testOnly += "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000"
 
 lazy val mavenTests = taskKey[Unit]("Execute integration tests using Maven")
 Test / mavenTests := Resolvers.run("mvn", "verify", "-f", "it/pom.xml",

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>jarmoniuk.nl</groupId>
   <artifactId>jetty-download-it</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.0</version>
   <packaging>pom</packaging>
 
   <name>Maven integration tests</name>

--- a/src/main/resources/META-INF/maven/plugin.xml
+++ b/src/main/resources/META-INF/maven/plugin.xml
@@ -4,7 +4,7 @@
   <description>Simple download plugin based on Eclipse Jetty.</description>
   <groupId>nl.jarmoniuk</groupId>
   <artifactId>jetty-download-maven-plugin</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.0.1</version>
   <goalPrefix>jetty-download</goalPrefix>
   <isolatedRealm>false</isolatedRealm>
   <inheritedByDefault>true</inheritedByDefault>

--- a/src/main/scala/nl/jarmoniuk/download/DownloadMojo.scala
+++ b/src/main/scala/nl/jarmoniuk/download/DownloadMojo.scala
@@ -34,9 +34,7 @@ import java.nio.file.StandardOpenOption
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.function.LongConsumer
-import scala.concurrent.Future
-import scala.concurrent.Promise
-import scala.language.postfixOps
+import nl.jarmoniuk.download.service.DownloadServiceException
 
 /**
  * Downloads the requested resource.
@@ -170,6 +168,7 @@ class DownloadMojo extends AbstractMojo:
 
   given log: Log = getLog
 
+  @throws[MojoExecutionException | MojoFailureException]
   override def execute(): Unit =
     try
       DownloadService.download(uri, outputFile.toPath, Option apply DownloadOptions(
@@ -199,7 +198,10 @@ class DownloadMojo extends AbstractMojo:
         certAlias = Option apply certAlias map (_.trim) filter (_.nonEmpty)
       ))
     catch
-      case e: Exception => throw MojoExecutionException(e)
+      case e: Exception =>
+        if log.isDebugEnabled then
+          log debug ("Caught exception %s" format e.toString)
+        throw new MojoFailureException(e)
 
 object DownloadMojo:
   private def basicAuthenticationFor(uri: URI, realm: String, username: String, password: String) =

--- a/src/main/scala/nl/jarmoniuk/download/service/DownloadService.scala
+++ b/src/main/scala/nl/jarmoniuk/download/service/DownloadService.scala
@@ -29,61 +29,101 @@ import scala.concurrent.{Await, ExecutionContext, Promise}
 import scala.util.Using.Releasable
 import scala.util.{Try, Using}
 
-case class AuthOptions(authentication: Authentication,
-                       preemptive: Boolean = false)
+case class AuthOptions(
+    authentication: Authentication,
+    preemptive: Boolean = false
+)
 
-case class ProxyOptions(uri: URI,
-                        authOptions: Option[AuthOptions] = None)
+case class ProxyOptions(uri: URI, authOptions: Option[AuthOptions] = None)
 
-case class DownloadOptions(authOptions: Option[AuthOptions] = None,
-                           proxyOptions: Option[ProxyOptions] = None,
-                           validateHostName: Boolean = true,
-                           trustAll: Boolean = false,
-                           validateCerts: Boolean = true,
-                           validatePeerCerts: Boolean = true,
-                           keyStorePath: Option[String] = None,
-                           keyStorePassword: Option[String] = None,
-                           trustStorePath: Option[String] = None,
-                           trustStorePassword: Option[String] = None,
-                           certAlias: Option[String] = None)
+case class DownloadOptions(
+    authOptions: Option[AuthOptions] = None,
+    proxyOptions: Option[ProxyOptions] = None,
+    validateHostName: Boolean = true,
+    trustAll: Boolean = false,
+    validateCerts: Boolean = true,
+    validatePeerCerts: Boolean = true,
+    keyStorePath: Option[String] = None,
+    keyStorePassword: Option[String] = None,
+    trustStorePath: Option[String] = None,
+    trustStorePassword: Option[String] = None,
+    certAlias: Option[String] = None
+)
 
 object DownloadService:
   private class ProgressTracker(using log: Log) extends Runnable:
     private var _contentLength: Option[Long] = None
     private val _bytesDownloaded = new AtomicLong(0L)
 
-    def updateBytesDownloaded(delta: Long): Long = _bytesDownloaded.addAndGet(delta)
+    def updateBytesDownloaded(delta: Long): Long =
+      _bytesDownloaded.addAndGet(delta)
     def getBytesDownloaded: Long = _bytesDownloaded.get
-    def provideContentLength(contentLength: Long): Unit = _contentLength = Some(contentLength)
+    def provideContentLength(contentLength: Long): Unit = _contentLength = Some(
+      contentLength
+    )
     override def run(): Unit =
       val downloaded = _bytesDownloaded.get
-      val status = _contentLength.map(totalSize => "Downloaded %d bytes - %3d%%"
-        .format(downloaded, (100.0 * downloaded / totalSize).round))
+      val status = _contentLength
+        .map(totalSize =>
+          "Downloaded %d bytes - %3d%%"
+            .format(downloaded, (100.0 * downloaded / totalSize).round)
+        )
         .orElse(Some("Downloaded %d bytes".format(downloaded)))
         .get
       log info status
 
-  private[this] def processOptions(options: DownloadOptions)
-                                  (using httpClient: HttpClient,
-                                   sslContextFactory: SslContextFactory): Unit =
+  private[this] def processOptions(
+      options: DownloadOptions
+  )(using httpClient: HttpClient, sslContextFactory: SslContextFactory): Unit =
     options.authOptions foreach { authOptions =>
-      httpClient.getAuthenticationStore.addAuthentication(authOptions.authentication)
+      httpClient.getAuthenticationStore.addAuthentication(
+        authOptions.authentication
+      )
       if authOptions.preemptive then
-        Option.apply(authOptions.authentication.authenticate(null, null,
-          new HeaderInfo(HttpHeader.AUTHORIZATION, null,
-            singletonMap("charset", StandardCharsets.ISO_8859_1.toString)), null))
+        Option
+          .apply(
+            authOptions.authentication.authenticate(
+              null,
+              null,
+              new HeaderInfo(
+                HttpHeader.AUTHORIZATION,
+                null,
+                singletonMap("charset", StandardCharsets.ISO_8859_1.toString)
+              ),
+              null
+            )
+          )
           .foreach(httpClient.getAuthenticationStore.addAuthenticationResult)
     }
 
     options.proxyOptions foreach { proxyOptions =>
-      httpClient.getProxyConfiguration.getProxies.add(new HttpProxy(new Origin.Address(proxyOptions.uri.getHost,
-        proxyOptions.uri.getPort), "https" equalsIgnoreCase proxyOptions.uri.getScheme))
+      httpClient.getProxyConfiguration.getProxies.add(
+        new HttpProxy(
+          new Origin.Address(
+            proxyOptions.uri.getHost,
+            proxyOptions.uri.getPort
+          ),
+          "https" equalsIgnoreCase proxyOptions.uri.getScheme
+        )
+      )
       proxyOptions.authOptions foreach { authOptions =>
-        httpClient.getAuthenticationStore.addAuthentication(authOptions.authentication)
+        httpClient.getAuthenticationStore.addAuthentication(
+          authOptions.authentication
+        )
         if authOptions.preemptive then
-          Option.apply(authOptions.authentication.authenticate(null, null,
-            new HeaderInfo(HttpHeader.PROXY_AUTHORIZATION, null,
-              singletonMap("charset", StandardCharsets.ISO_8859_1.toString)), null))
+          Option
+            .apply(
+              authOptions.authentication.authenticate(
+                null,
+                null,
+                new HeaderInfo(
+                  HttpHeader.PROXY_AUTHORIZATION,
+                  null,
+                  singletonMap("charset", StandardCharsets.ISO_8859_1.toString)
+                ),
+                null
+              )
+            )
             .foreach(httpClient.getAuthenticationStore.addAuthenticationResult)
       }
     }
@@ -100,68 +140,94 @@ object DownloadService:
     options.trustStorePassword foreach sslContextFactory.setTrustStorePassword
     options.certAlias foreach sslContextFactory.setCertAlias
 
-  def download(uri: URI, outputPath: Path, options: Option[DownloadOptions] = None)(using log: Log): Response =
+  def download(
+      uri: URI,
+      outputPath: Path,
+      options: Option[DownloadOptions] = None
+  )(using log: Log): Response =
     val progressTracker = new ProgressTracker
     val response = Promise[Response]
-    val progressFuture = Executors.newScheduledThreadPool(1)
+    val progressFuture = Executors
+      .newScheduledThreadPool(1)
       .scheduleAtFixedRate(progressTracker, 1, 1, TimeUnit.SECONDS)
 
-    given Releasable[HttpClient] = client => if client.isStarted then client.stop()
-    given Releasable[Path] = path =>
-      if response.future.value.get.get.getStatus == HttpStatus.OK_200 then
-        Files.copy(path, outputPath, StandardCopyOption.REPLACE_EXISTING)
-      Files.deleteIfExists(path)
+    val sslContextFactory = SslContextFactory.Client()
+    val httpClient = HttpClient(sslContextFactory)
 
-    Using.Manager { use =>
-      try
-        val sslContextFactory = SslContextFactory.Client()
-        val httpClient = HttpClient(sslContextFactory)
+    try
+      given HttpClient = httpClient
+      given SslContextFactory = sslContextFactory
+      options foreach processOptions
 
-        given HttpClient = httpClient
-        given SslContextFactory = sslContextFactory
-        options foreach processOptions
-
-        val tempFile = use(Files.createTempFile("downloader-", ".bin"))
-        val outChannel = use(FileChannel.open(tempFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING,
-          StandardOpenOption.WRITE))
-
+      Using.Manager { use =>
+        val tempFile = use(Files.createTempFile("downloader-", ".bin"))(Files.deleteIfExists(_))
+        val outChannel = use(
+          FileChannel.open(
+            tempFile,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.TRUNCATE_EXISTING,
+            StandardOpenOption.WRITE
+          )
+        )
         httpClient.start()
-        httpClient.newRequest(uri)
+        if log.isDebugEnabled then
+          log debug "Opening %s for download".format(uri.toString)
+        httpClient
+          .newRequest(uri)
           .onResponseHeaders { listener =>
-            if log.isInfoEnabled then
+            if log.isDebugEnabled then
               listener.getHeaders.stream
-                .map(field => "\t%s: %s\n" format(field.getName, field.getValue))
+                .map(field =>
+                  "\t%s: %s\n" format (field.getName, field.getValue)
+                )
                 .reduce((s1, s2) => s1 + s2)
-                .ifPresent(l => log.info("Headers:\n%s\n" format l))
+                .ifPresent(l => log.debug("Headers:\n%s\n" format l))
               (Option apply listener.getHeaders.get(CONTENT_LENGTH))
                 .map(_.toLong) foreach progressTracker.provideContentLength
           }
-          .onResponseContentDemanded { (_: Response, demand: LongConsumer, byteBuffer: ByteBuffer, callback: Callback) =>
-            try
-              val bytesWritten = outChannel.write(byteBuffer)
-              progressTracker.updateBytesDownloaded(bytesWritten)
+          .onResponseContentDemanded {
+            (
+                _: Response,
+                demand: LongConsumer,
+                byteBuffer: ByteBuffer,
+                callback: Callback
+            ) =>
+              try
+                val bytesWritten = outChannel.write(byteBuffer)
+                progressTracker.updateBytesDownloaded(bytesWritten)
 
-              demand.accept(1)
-              callback.succeeded()
-            catch
-              case e: IOException =>
-                log warn "I/O error while writing data: " + e.getMessage
-                callback.failed(e)
-              case t: Throwable =>
-                log warn "Unknown error: " + t.getMessage
-                callback.failed(t)
+                demand.accept(1)
+                callback.succeeded()
+              catch
+                case e: IOException =>
+                  log warn "I/O error while writing data: " + e.getMessage
+                  callback.failed(e)
+                case t: Throwable =>
+                  log warn "Unknown error: " + t.getMessage
+                  callback.failed(t)
           }
-          .send(result =>
+          .send { result =>
+            if log.isDebugEnabled then
+              log debug ("Result: %s" format(result.getResponse.toString()))
             if !result.isFailed then response.success(result.getResponse)
-            else response.failure(result.getFailure))
+            else response.failure(result.getFailure)
+          }
         Await.result(response.future, Duration.Inf)
         val responseVal = response.future.value.get.get
         if responseVal.getStatus == HttpStatus.OK_200 then
           log info ("Downloaded %d bytes." format progressTracker.getBytesDownloaded)
-        else
-          log warn ("Returned code " + responseVal.getStatus)
-
+          Files.copy(tempFile, outputPath, StandardCopyOption.REPLACE_EXISTING)
+        else throw DownloadServiceException(responseVal.getStatus, responseVal.getReason())
         responseVal
-      finally
-        progressFuture.cancel(false)
-    }.get
+      }.get
+    catch
+      case e: Exception =>
+        log error "Caught exception %s".format(e.toString)
+        Option apply e.getCause foreach (e =>
+          e.getStackTrace to LazyList map (_.toString) foreach (log info "\t" + _))
+        throw e
+    finally
+      progressFuture.cancel(false)
+      // disabling since this causes a java.nio.channels.ClosedChannelException from FillInterest.onClose
+      // if httpClient.isRunning then httpClient.stop()
+      

--- a/src/main/scala/nl/jarmoniuk/download/service/DownloadServiceException.scala
+++ b/src/main/scala/nl/jarmoniuk/download/service/DownloadServiceException.scala
@@ -1,0 +1,4 @@
+package nl.jarmoniuk.download.service
+
+case class DownloadServiceException(httpStatus: Int, message: String) extends Exception(message) {
+}

--- a/src/site/index.adoc
+++ b/src/site/index.adoc
@@ -5,7 +5,7 @@
 
 This is http://www.jarmoniuk.nl/jetty-download/[jetty-download-maven-plugin], a simple Maven plugin for downloading resources, using https://www.eclipse.org/jetty/[Eclipse Jetty].
 
-image:https://img.shields.io/github/license/mojohaus/versions-maven-plugin.svg?label=License[Apache License, Version 2.0, January 2004,link=https://www.apache.org/licenses/LICENSE-2.0]
+image:https://img.shields.io/github/license/mojohaus/versions-maven-plugin.svg?label=License[Apache License,Version 2.0,January 2004,link=https://www.apache.org/licenses/LICENSE-2.0]
 image:https://img.shields.io/maven-central/v/nl.jarmoniuk/jetty-download-maven-plugin.svg?label=Maven%20Central[Maven Central,link=https://search.maven.org/artifact/nl.jarmoniuk/jetty-download-maven-plugin]
 image:https://github.com/ajarmoniuk/jetty-download-maven-plugin/actions/workflows/scala.yml/badge.svg[Build Status,link=https://github.com/ajarmoniuk/jetty-download-maven-plugin/actions/workflows/scala.yml]
 
@@ -13,15 +13,17 @@ image:https://github.com/ajarmoniuk/jetty-download-maven-plugin/actions/workflow
 
 In contradiction to other avaialable Maven plugins for downloading resources, this one uses https://www.eclipse.org/jetty/[Eclipse Jetty] version @jettyVersion@, and tries to do only one thing.
 
-A big part of the _why_ is -- because it's _fun!_ That's also why this plugin, whilst working with Java 8 and Maven, is written using Scala 3 (Dotty). Despite the ludic component to it, the main goal is to offer solid functionality with the Unix philosophy of doing just one thing -- but doing it well.
+The plugin is written using Scala 3 (Dotty).
 
 == Similar plugins
 
-Probably the most widely known similar plugin is the https://github.com/maven-download-plugin/maven-download-plugin[download-maven-plugin]. It is based on https://hc.apache.org/httpcomponents-client-5.2.x/[Apache HttpClient] and offers e.g. checksum checking, unarchiving, caching, and many more features.
+Probably the most widely known similar plugin is the https://github.com/maven-download-plugin/maven-download-plugin[download-maven-plugin].
+It is based on https://hc.apache.org/httpcomponents-client-5.2.x/[Apache HttpClient] and offers e.g. checksum checking, unarchiving, caching, and many more features.
 
 == Maintained versions
 
-Jetty Download Maven Plugin [.underline]#requires Maven 3.3.9+ and Java 8+#. However, we maintain the latest Plugin version with the latest Maven.
+Jetty Download Maven Plugin [.underline]#requires Maven 3.3.9+ and Java 8+#.
+However, we maintain the latest Plugin version with the latest Maven.
 
 Plugin is tested with Java 8, 11, and 17 running on Ubuntu, Windows, and MacOS using https://github.com/ajarmoniuk/jetty-download-maven-plugin/actions/workflows/scala.yml[GitHub Actions]
 
@@ -29,7 +31,8 @@ Plugin is tested with Java 8, 11, and 17 running on Ubuntu, Windows, and MacOS u
 
 The plugin should be available in Central maven repository.
 
-The plugin only offers one goal, `download`, which should download the given resource to the given file location. In order to use the plugin from pom.xml, an example `build` usage would look like this:
+The plugin only offers one goal, `download`, which should download the given resource to the given file location.
+In order to use the plugin from pom.xml, an example `build` usage would look like this:
 
 [source,xml]
 ----

--- a/src/test/scala/nl/jarmoniuk/download/service/DownloadServiceHttpTest.scala
+++ b/src/test/scala/nl/jarmoniuk/download/service/DownloadServiceHttpTest.scala
@@ -3,7 +3,7 @@ package nl.jarmoniuk.download.service
 import nl.jarmoniuk.download.authentication.BasicAuthProxyAuthenticator
 import nl.jarmoniuk.download.service.DownloadServiceTestBase.helloWorldHandler
 import nl.jarmoniuk.download.service.{DownloadServiceTestBase, AuthOptions, DownloadOptions, DownloadService, ProxyOptions}
-import nl.jarmoniuk.download.util.SimpleTextHandler
+import nl.jarmoniuk.download.test.SimpleTextHandler
 import org.apache.maven.plugin.logging.{Log, SystemStreamLog}
 import org.eclipse.jetty.client.api.Authentication
 import org.eclipse.jetty.client.api.Authentication.ANY_REALM
@@ -14,7 +14,6 @@ import org.eclipse.jetty.http.{HttpHeader, HttpStatus}
 import org.eclipse.jetty.proxy.{ConnectHandler, ProxyServlet}
 import org.eclipse.jetty.security.*
 import org.eclipse.jetty.security.authentication.{BasicAuthenticator, LoginAuthenticator}
-import org.eclipse.jetty.server.*
 import org.eclipse.jetty.server.handler.{AbstractHandler, ContextHandler, ErrorHandler, HandlerWrapper}
 import org.eclipse.jetty.servlet.{FilterHolder, ServletContextHandler, ServletHolder}
 import org.eclipse.jetty.util.security.{Constraint, Password}
@@ -33,18 +32,10 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import scala.io.Source
 import scala.util.Using
 import scala.util.Using.Releasable
+import nl.jarmoniuk.download.test.*
+import org.eclipse.jetty.server.Request
 
 class DownloadServiceHttpTest extends DownloadServiceTestBase with Matchers:
-
-  private class PlainHttpServer(val handler: Server => Handler) extends Server:
-    private lazy val serverConnector = ServerConnector(this, 1, 1)
-    private[this] def init(): Unit =
-      addConnector(serverConnector)
-      setHandler(handler(this))
-    init()
-
-  private object PlainHttpServer:
-    given Releasable[PlainHttpServer] = _.stop()
 
   "a client" should "download a \"Hello, world!\" message" in {
     Using.Manager { use =>

--- a/src/test/scala/nl/jarmoniuk/download/service/DownloadServiceHttpsTest.scala
+++ b/src/test/scala/nl/jarmoniuk/download/service/DownloadServiceHttpsTest.scala
@@ -2,7 +2,7 @@ package nl.jarmoniuk.download.service
 
 import nl.jarmoniuk.download.service.DownloadServiceTestBase.helloWorldHandler
 import nl.jarmoniuk.download.service.{DownloadServiceTestBase, AuthOptions, DownloadOptions, DownloadService}
-import nl.jarmoniuk.download.util.SimpleTextHandler
+import nl.jarmoniuk.download.test.SimpleTextHandler
 import org.apache.maven.plugin.logging.{Log, SystemStreamLog}
 import org.eclipse.jetty.client.HttpProxy
 import org.eclipse.jetty.client.api.Authentication.ANY_REALM
@@ -25,29 +25,9 @@ import java.nio.file.{Files, Path}
 import scala.io.Source
 import scala.util.Using
 import scala.util.Using.{Releasable, resource}
+import nl.jarmoniuk.download.test.*
 
 class DownloadServiceHttpsTest extends DownloadServiceTestBase with Matchers:
-
-  private class HttpsServer(val handler: Server => Handler) extends Server with Releasable[HttpsServer]:
-    override def release(resource: HttpsServer = this): Unit = resource.stop()
-    private[this] def init(): Unit =
-      val sslContextFactory = SslContextFactory.Server()
-      sslContextFactory.setKeyStorePath(getClass.getResource("/keystore-testhost.jks").getPath)
-      sslContextFactory.setKeyStorePassword("password")
-
-      val src = new SecureRequestCustomizer
-      src.setSniHostCheck(false)
-
-      val httpsConfig = new HttpConfiguration
-      httpsConfig.addCustomizer(src)
-
-      val serverConnector = ServerConnector(this, sslContextFactory, new HttpConnectionFactory(httpsConfig))
-      addConnector(serverConnector)
-      setHandler(handler(this))
-    init()
-
-  private object HttpsServer:
-    given Releasable[HttpsServer] = _.stop()
 
   "a client" should "download a \"Hello, world!\" message" in {
     Using.Manager { use =>

--- a/src/test/scala/nl/jarmoniuk/download/service/DownloadServiceTestBase.scala
+++ b/src/test/scala/nl/jarmoniuk/download/service/DownloadServiceTestBase.scala
@@ -1,7 +1,7 @@
 package nl.jarmoniuk.download.service
 
 import nl.jarmoniuk.download.authentication.BasicAuthProxyAuthenticator
-import nl.jarmoniuk.download.util.SimpleTextHandler
+import nl.jarmoniuk.download.test.SimpleTextHandler
 import org.apache.maven.plugin.logging.{Log, SystemStreamLog}
 import org.eclipse.jetty.proxy.ProxyServlet
 import org.eclipse.jetty.security.*
@@ -15,6 +15,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 import java.nio.file.{Files, Path}
 import scala.util.Using.Releasable
+import nl.jarmoniuk.download.test.*
 
 object DownloadServiceTestBase:
   lazy val helloWorldHandler = SimpleTextHandler("Hello, world!")
@@ -25,26 +26,6 @@ abstract class DownloadServiceTestBase extends AnyFlatSpec with BeforeAndAfterEa
   private lazy val _log = new SystemStreamLog
   protected given Log = _log
   protected given LoginAuthenticator = new BasicAuthenticator
-
-  class TempFile(val prefix: String = "download"):
-    private lazy val _path = Files.createTempFile(prefix + "-", ".tmp")
-    def path: Path = _path
-
-  object TempFile:
-    given Releasable[TempFile] = f => Files.deleteIfExists(f._path)
-
-  class PlainHttpProxy extends Server:
-    private lazy val _connector = ServerConnector(this, 1, 1)
-    private lazy val _context = ServletContextHandler(this, "/", ServletContextHandler.SESSIONS)
-    def connector: ServerConnector = _connector
-    def context: ServletContextHandler = _context
-    private[this] def init(): Unit =
-      addConnector(_connector)
-      _context.addServlet(ServletHolder(classOf[ProxyServlet]), "/*")
-    init()
-
-  object PlainHttpProxy:
-    given Releasable[PlainHttpProxy] = _.stop()
 
   class HttpsProxy extends Server:
     private var _connector: ServerConnector = _

--- a/src/test/scala/nl/jarmoniuk/download/test/HttpsServer.scala
+++ b/src/test/scala/nl/jarmoniuk/download/test/HttpsServer.scala
@@ -1,0 +1,27 @@
+package nl.jarmoniuk.download.test
+
+import org.eclipse.jetty.server.*
+import scala.util.Using.Releasable
+import org.eclipse.jetty.util.ssl.SslContextFactory
+
+class HttpsServer(val handler: Server => Handler) extends Server with Releasable[HttpsServer]:
+    override def release(resource: HttpsServer = this): Unit = resource.stop()
+    private[this] def init(): Unit =
+      val sslContextFactory = SslContextFactory.Server()
+      sslContextFactory.setKeyStorePath(getClass.getResource("/keystore-testhost.jks").getPath)
+      sslContextFactory.setKeyStorePassword("password")
+
+      val src = new SecureRequestCustomizer
+      src.setSniHostCheck(false)
+
+      val httpsConfig = new HttpConfiguration
+      httpsConfig.addCustomizer(src)
+
+      val serverConnector = ServerConnector(this, sslContextFactory, new HttpConnectionFactory(httpsConfig))
+      addConnector(serverConnector)
+      setHandler(handler(this))
+    init()
+
+object HttpsServer:
+    given Releasable[HttpsServer] = _.stop()
+

--- a/src/test/scala/nl/jarmoniuk/download/test/PlainHttpProxy.scala
+++ b/src/test/scala/nl/jarmoniuk/download/test/PlainHttpProxy.scala
@@ -1,0 +1,21 @@
+package nl.jarmoniuk.download.test
+
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.ServerConnector
+import org.eclipse.jetty.servlet.ServletContextHandler
+import scala.util.Using.Releasable
+import org.eclipse.jetty.servlet.ServletHolder
+import org.eclipse.jetty.proxy.ProxyServlet
+
+class PlainHttpProxy extends Server:
+    private lazy val _connector = ServerConnector(this, 1, 1)
+    private lazy val _context = ServletContextHandler(this, "/", ServletContextHandler.SESSIONS)
+    def connector: ServerConnector = _connector
+    def context: ServletContextHandler = _context
+    private[this] def init(): Unit =
+      addConnector(_connector)
+      _context.addServlet(ServletHolder(classOf[ProxyServlet]), "/*")
+    init()
+
+object PlainHttpProxy:
+    given Releasable[PlainHttpProxy] = _.stop()

--- a/src/test/scala/nl/jarmoniuk/download/test/PlainHttpServer.scala
+++ b/src/test/scala/nl/jarmoniuk/download/test/PlainHttpServer.scala
@@ -1,0 +1,14 @@
+package nl.jarmoniuk.download.test
+
+import org.eclipse.jetty.server.*
+import scala.util.Using.Releasable
+
+class PlainHttpServer(val handler: Server => Handler) extends Server:
+    private lazy val serverConnector = ServerConnector(this, 1, 1)
+    private[this] def init(): Unit =
+        addConnector(serverConnector)
+        setHandler(handler(this))
+    init()
+
+object PlainHttpServer:
+    given Releasable[PlainHttpServer] = _.stop()

--- a/src/test/scala/nl/jarmoniuk/download/test/SimpleTextHandler.scala
+++ b/src/test/scala/nl/jarmoniuk/download/test/SimpleTextHandler.scala
@@ -1,4 +1,4 @@
-package nl.jarmoniuk.download.util
+package nl.jarmoniuk.download.test
 
 import org.eclipse.jetty.http.{HttpHeader, HttpStatus}
 import org.eclipse.jetty.server.Request

--- a/src/test/scala/nl/jarmoniuk/download/test/TempFile.scala
+++ b/src/test/scala/nl/jarmoniuk/download/test/TempFile.scala
@@ -1,0 +1,11 @@
+package nl.jarmoniuk.download.test
+
+import scala.util.Using.Releasable
+import java.nio.file.{Path, Files}
+
+class TempFile(val prefix: String = "download"):
+    private lazy val _path = Files.createTempFile(prefix + "-", ".tmp")
+    def path: Path = _path
+
+object TempFile:
+    given Releasable[TempFile] = f => Files.deleteIfExists(f._path)


### PR DESCRIPTION
- bugfix: errors or attempts download from a non-existing resource caused the plugin to throw an IllegalArgumentException with the actual exception being suppressed